### PR TITLE
Refresh citations data

### DIFF
--- a/_data/citations.yaml
+++ b/_data/citations.yaml
@@ -329,10 +329,10 @@
 - id: doi:10.19066/cogsci.2007.18.4.002
   title: The Influence of Depth Context on Blind Spot Filling-in
   authors:
-  - ' Sang Chul Chong'
   - " \uBC15\uACBD\uBBF8"
-  - " \uCC28\uC625\uADE0"
   - " \uAE40\uC0C1\uB798"
+  - ' Sang Chul Chong'
+  - ' Oakyoon Cha'
   - " \uC784\uD76C\uC5F0"
   publisher: Korean Journal of Cognitive Science
   date: '2007-12-01'
@@ -386,61 +386,42 @@
   orcid: 0000-0001-9379-1347
   plugin: orcid.py
   file: orcid.yaml
-- id: doi:10.1371/journal.pcbi.1007128
-  title: Open collaborative writing with Manubot
+- id: doi:10.1016/j.neuroimage.2026.122145
+  title: 'Developmental changes in MEG oscillatory activity during visuomotor adaptation:
+    Differential maturation of feedforward and feedback-related mechanisms'
   authors:
-  - Daniel S. Himmelstein
-  - Vincent Rubinetti
-  - David R. Slochower
-  - Dongbo Hu
-  - Venkat S. Malladi
-  - Casey S. Greene
-  - Anthony Gitter
-  publisher: PLOS Computational Biology
-  date: '2020-12-04'
-  link: https://doi.org/c7np
-  type: paper
-  description: Lorem ipsum _dolor_ **sit amet**, consectetur adipiscing elit, sed
-    do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-  image: https://journals.plos.org/ploscompbiol/article/figure/image?size=inline&id=info:doi/10.1371/journal.pcbi.1007128.g001&rev=2
-  buttons:
-  - type: manubot
-    link: https://greenelab.github.io/meta-review/
-  - type: source
-    text: Manuscript Source
-    link: https://github.com/greenelab/meta-review
-  - type: website
-    link: https://manubot.org/
-  tags:
-  - open science
-  - collaboration
-  repo: greenelab/meta-review
+  - Minsu Song
+  - Alexander J. Cook
+  - Advitya Hajela
+  - Deborah Giaschi
+  - Hee-Yeon Im
+  publisher: NeuroImage
+  date: '2026-10-01'
+  link: https://doi.org/hcct5s
   plugin: sources.py
   file: sources.yaml
-- id: doi:10.1016/j.csbj.2020.05.017
-  title: Constructing knowledge graphs and their biomedical applications
+- id: doi:10.1002/icd.70121
+  title: "Speed and Accuracy of Movement During Visuomotor Adaptation Are Still Developing\
+    \ in School\u2010Age Children"
   authors:
-  - David N. Nicholson
-  - Casey S. Greene
-  publisher: Computational and Structural Biotechnology Journal
-  date: '2020-01-01'
-  link: https://doi.org/gg7m48
-  image: https://ars.els-cdn.com/content/image/1-s2.0-S2001037020302804-gr1.jpg
+  - Alexander J. Cook
+  - Deborah Giaschi
+  - Hee Yeon Im
+  publisher: Infant and Child Development
+  date: '2026-07-01'
+  link: https://doi.org/hcct5t
   plugin: sources.py
   file: sources.yaml
-- id: doi:10.7554/eLife.32822
-  title: Sci-Hub provides access to nearly all scholarly literature
+- id: doi:10.1016/j.visres.2025.108745
+  title: Evaluation of motion perception and binocular vision following dichoptic
+    treatment for amblyopia
   authors:
-  - Daniel S Himmelstein
-  - Ariel Rodriguez Romero
-  - Jacob G Levernier
-  - Thomas Anthony Munro
-  - Stephen Reid McLaughlin
-  - Bastian Greshake Tzovaras
-  - Casey S Greene
-  publisher: eLife
-  date: '2018-03-01'
-  link: https://doi.org/ckcj
-  image: https://iiif.elifesciences.org/lax:32822%2Felife-32822-fig8-v3.tif/full/863,/0/default.webp
+  - Akosua Kesewah Asare
+  - Cindy S. Ho
+  - Hee Yeon Im
+  - Deborah Eileen Giaschi
+  publisher: Vision Research
+  date: '2026-03-01'
+  link: https://doi.org/hcct5v
   plugin: sources.py
   file: sources.yaml


### PR DESCRIPTION
Regenerates `_data/citations.yaml` via the repo's `update-citations` workflow, picking up the corrected `_data/sources.yaml`.

- Removes the three Greene Lab template demo citations (Manubot, knowledge graphs, Sci-Hub) that shipped with the site template.
- Adds the three recent lab papers ORCID has not indexed yet: Song et al. 2026 (NeuroImage), Cook et al. 2026 (Infant and Child Development), Asare et al. 2026 (Vision Research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)