### PR TITLE
Generate publications list from citation data; switch font to Atkinson Hyperlegible Next

### DIFF
--- a/Publications/index.md
+++ b/Publications/index.md
@@ -8,7 +8,7 @@ nav:
 <h1 style="text-align: left;">Publications</h1>
 
 <style>
-  /* alignment + hanging indent (unchanged) */
+  /* alignment + hanging indent */
   .pubs, .pubs li {
     text-align: left !important;
     text-align-last: auto !important;
@@ -20,120 +20,42 @@ nav:
   .pubs li { margin-bottom: 1.5rem; padding-left: 1.2em; text-indent: -1.2em; }
   .pubs a { overflow-wrap: anywhere; word-break: break-word; }
 
-  /* FORCE normal text color for this section */
-  .pubs { color: #111 !important; }
-  .pubs * { color: inherit !important; }
+  /* follow the light/dark theme rather than forcing a fixed colour */
+  .pubs { color: var(--text); }
+  .pubs * { color: inherit; }
 </style>
-    
+
+<!--
+  This list is generated from _data/citations.yaml, which is built by
+  _cite/cite.py from the lab ORCID record plus _data/sources.yaml.
+  To add a paper, add its DOI to _data/sources.yaml — don't edit this list.
+-->
+
+{%- assign pubs = site.data.citations | sort: "date" | reverse -%}
+
 <ul class="pubs">
-    <li>
-      Song, M., Cook, A. J., Hajela, A., Giaschi, D. E., &amp; Im, H. Y. (2026). Developmental changes in MEG oscillatory activity during visuomotor adaptation: Differential maturation of feedforward and feedback-related mechanisms.
-      <i>NeuroImage</i>, <i>339</i>, 122145.
-      <a href="https://doi.org/10.1016/j.neuroimage.2026.122145" target="_blank" rel="noopener noreferrer">https://doi.org/10.1016/j.neuroimage.2026.122145</a>
-    </li>
-    <li>
-      Cook, A. J., Giaschi, D. E., &amp; Im, H. Y. (2026). Speed and accuracy of movement during visuomotor adaptation are still developing in school-age children.
-      <i>Infant and Child Development</i>, <i>35</i>(4), e70121.
-      <a href="https://doi.org/10.1002/icd.70121" target="_blank" rel="noopener noreferrer">https://doi.org/10.1002/icd.70121</a>
-    </li>
-    <li>
-      Asare, A. K., Ho, C., Im, H. Y., &amp; Giaschi, D. E. (2026). Evaluation of motion perception and binocular vision following dichoptic treatment for amblyopia.
-      <i>Vision Research</i>, <i>240</i>, 108745.
-      <a href="https://doi.org/10.1016/j.visres.2025.108745" target="_blank" rel="noopener noreferrer">https://doi.org/10.1016/j.visres.2025.108745</a>
-    </li>
-    <li>
-      Cook, A. J., Im, H. Y., &amp; Giaschi, D. E. (2025). Large-scale functional networks underlying visual attention.
-      <i>Neuroscience &amp; Biobehavioral Reviews</i>, <i>173</i>, 106165.
-      <a href="https://doi.org/10.1016/j.neubiorev.2025.106165" target="_blank" rel="noopener noreferrer">https://doi.org/10.1016/j.neubiorev.2025.106165</a>
-    </li>
-    <li style="margin-bottom: 1.5rem; padding-left: 1.2em; text-indent: -1.2em;">
-      Son, G., Im, H. Y., Albohn, D. N., Kveraga, K., Adams, R. B., Sun, J., & Chong, S. (2023). Americans weigh an attended emotion more than Koreans in overall mood judgements. <i>Scientific Reports, 13(1)</i>.
-      <a href="https://doi.org/10.1038/s41598-023-46723-7" target="_blank" rel="noopener noreferrer">
-      https://doi.org/10.1038/s41598-023-46723-7
-      </a>
-    </li>
-    <li>
-      Cho, J., Im, H. Y., Yoon, Y. J., Joo, S. J., & Chong, S. C. (2023). The effect of masks on the emotion perception of a facial crowd. <i>Scientific Reports, 13</i>.
-      <a href="https://doi.org/10.1038/s41598-023-41366-0" target="_blank" rel="noopener noreferrer">https://doi.org/10.1038/s41598-023-41366-0</a>
-    </li>
-    <li>
-      Im, H. Y., Liddy, J. J., & Song, J. H. (2022). Inconsistent attentional contexts impair relearning following gradual visuomotor adaptation. <i>Journal of Neurophysiology, 128(3)</i>.
-      <a href="https://doi.org/10.1152/jn.00463.2021" target="_blank" rel="noopener noreferrer">https://doi.org/10.1152/jn.00463.2021</a>
-    </li>
-    <li>
-      Im, H. Y., Cushing, C., Ward, N., & Kveraga, K. (2021). Differential neurodynamics and connectivity in the dorsal and ventral visual pathways during perception of emotional crowds: a MEG study. <i>Cognitive, Affective, and Behavioral Neuroscience</i>.
-      <a href="https://doi.org/10.3758/s13415-021-00880-2" target="_blank" rel="noopener noreferrer">https://doi.org/10.3758/s13415-021-00880-2</a>
-    </li>
-    <li>
-      Im, H. Y., Tiurina, N. A., & Utochkin, I. S. (2020). An explicit investigation of the roles that feature distributions play in rapid visual categorization. <i>Attention, Perception, & Psychophysics</i>.
-      <a href="https://doi.org/10.3758/s13414-020-02046-7" target="_blank" rel="noopener noreferrer">https://doi.org/10.3758/s13414-020-02046-7</a>
-    </li>
-    <li>
-      Kveraga, K., Im, H. Y., Ward, N., & Adams, R. B. Jr. (2020). Fast saccadic and manual responses to faces presented to the koniocellular visual pathway. <i>Journal of Vision, 20(2)</i>.
-      <a href="https://doi.org/10.1167/jov.20.2.9" target="_blank" rel="noopener noreferrer">https://doi.org/10.1167/jov.20.2.9</a>
-    </li>
-    <li>
-      Adams, R. B. Jr., Im, H. Y., Cushing, C., Boshyan, J., Ward, N., Albohn, D. N., & Kveraga, K. (2019). Differential magnocellular versus parvocellular pathway contributions to the combinatorial processing of facial threat. <i>Progress in Brain Research, 247, 71–87</i>.
-      <a href="https://doi.org/10.1016/bs.pbr.2019.03.006" target="_blank" rel="noopener noreferrer">https://doi.org/10.1016/bs.pbr.2019.03.006</a>
-    </li>
-    <li>
-      Cushing, C., Im, H. Y., Adams, R. B. Jr., Ward, N., & Kveraga, K. (2019). Magnocellular and parvocellular pathway contributions to facial threat cue processing. <i>Social Cognitive and Affective Neuroscience, 14, 151–162</i>.
-      <a href="https://doi.org/10.1093/scan/nsz003" target="_blank" rel="noopener noreferrer">https://doi.org/10.1093/scan/nsz003</a>
-    </li>
-    <li>
-      Kveraga, K., De Vito, D., Cushing, C., Im, H. Y., Albohn, D. N., & Adams, R. B. Jr. (2019). Spatial and feature-based attention to expressive faces. <i>Experimental Brain Research, 4, 967–975</i>.
-      <a href="https://link.springer.com/article/10.1007/s00221-019-05472-8" target="_blank" rel="noopener noreferrer">https://link.springer.com/article/10.1007/s00221-019-05472-8</a>
-    </li>
-    <li>
-      Im, H. Y., Adams, R. B. Jr., Cushing, C., Boshyan, J., Ward, N., & Kveraga, K. (2018). Sex-related differences in behavioral and amygdalar responses to compound facial threat cues. <i>Human Brain Mapping, 39, 2725–2741</i>.
-      <a href="https://onlinelibrary.wiley.com/doi/epdf/10.1002/hbm.24035" target="_blank" rel="noopener noreferrer">https://onlinelibrary.wiley.com/doi/epdf/10.1002/hbm.24035</a>
-    </li>
-    <li>
-      Cushing, C., Im, H. Y., Adams, R. B. Jr., Ward, N., Albohn, N. D., Steiner, T. G., & Kveraga, K. (2018). Neurodynamics and connectivity during facial fear perception: The role of threat exposure and signal congruity. <i>Scientific Reports, 8, 2776</i>.
-      <a href="https://www.nature.com/articles/s41598-018-20509-8" target="_blank" rel="noopener noreferrer">https://www.nature.com/articles/s41598-018-20509-8</a>
-    </li>
-    <li>
-      Im, H. Y., Adams, R. B. Jr., Boshyan, J., Ward, N., Cushing, C., & Kveraga, K. (2017). Observer’s anxiety facilitates magnocellular processing of clear facial threat cues, but impairs parvocellular processing of ambiguous facial threat cues. <i>Scientific Reports, 7, 15151</i>.
-      <a href="https://www.nature.com/articles/s41598-017-15495-2" target="_blank" rel="noopener noreferrer">https://www.nature.com/articles/s41598-017-15495-2</a>
-    </li>
-    <li>
-      Im, H. Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams, R. B. Jr., & Kveraga, K. (2017). Cross-cultural and hemispheric laterality effects on the ensemble coding of emotion in facial crowds. <i>Culture and Brain, 5, 125–152</i>.
-      <a href="https://link.springer.com/article/10.1007/s40167-017-0054-y" target="_blank" rel="noopener noreferrer">https://link.springer.com/article/10.1007/s40167-017-0054-y</a>
-    </li>
-    <li>
-      Im, H. Y., Albohn, N. D., Steiner, T. G., Cushing, C., Adams, R. B. Jr., & Kveraga, K. (2017). Ensemble coding of crowd emotion: Differential hemispheric and visual stream contributions. <i>Nature Human Behaviour, 1, 828–842</i>.
-      <a href="https://www.nature.com/articles/s41562-017-0225-z" target="_blank" rel="noopener noreferrer">https://www.nature.com/articles/s41562-017-0225-z</a>
-    </li>
-    <li>
-      Odic, D., Im, H. Y., Eisinger, R., Ly, R., & Halberda, J. (2016). PsiMLE: A maximum-likelihood estimation approach to estimating psychophysical scaling and variability more reliably, efficiently, and flexibly. <i>Behavioral Research Methods, 48, 445–462</i>.
-      <a href="https://link.springer.com/article/10.3758/s13428-015-0600-5" target="_blank" rel="noopener noreferrer">https://link.springer.com/article/10.3758/s13428-015-0600-5</a>
-    </li>
-    <li>
-      Im, H. Y., Bédard, P., & Song, J. H. (2016). Long lasting attentional-context dependent visuomotor memory. <i>Journal of Experimental Psychology: Human Perception & Performance, 42, 1269–1274</i>.
-      <a href="https://doi.org/10.1037/xhp0000271" target="_blank" rel="noopener noreferrer">https://doi.org/10.1037/xhp0000271</a>
-    </li>
-    <li>
-      Im, H. Y., Zhong, S., & Halberda, J. (2016). Grouping by proximity and the visual impression of approximate number in random dot arrays. <i>Vision Research, 126, 291–307</i>.
-      <a href="https://doi.org/10.1016/j.visres.2015.08.013" target="_blank" rel="noopener noreferrer">https://doi.org/10.1016/j.visres.2015.08.013</a>
-    </li>
-    <li>
-      Im, H. Y., Bédard, P., & Song, J. H. (2015). Encoding attentional states during visuomotor adaptation. <i>Journal of Vision, 15, 1–16</i>.
-      <a href="https://doi.org/10.1167/15.8.20" target="_blank" rel="noopener noreferrer">https://doi.org/10.1167/15.8.20</a>
-    </li>
-    <li>
-      Im, H. Y., Park, W., & Chong, S. C. (2015). Ensemble statistics as units of selection. <i>Journal of Cognitive Psychology, 27, 114–127</i>.
-      <a href="https://doi.org/10.1080/20445911.2014.985301" target="_blank" rel="noopener noreferrer">https://doi.org/10.1080/20445911.2014.985301</a>
-    </li>
-    <li>
-      Im, H. Y., & Chong, S. C. (2014). Mean size as a unit of visual working memory. <i>Perception, 43, 663–676</i>.
-      <a href="https://doi.org/10.1068/p7719" target="_blank" rel="noopener noreferrer">https://doi.org/10.1068/p7719</a>
-    </li>
-    <li>
-      Im, H. Y., & Halberda, J. (2013). The effects of sampling and internal noise on the representation of ensemble average size. <i>Attention, Perception, & Psychophysics, 75, 278–286</i>.
-      <a href="https://link.springer.com/article/10.3758/s13414-012-0399-4" target="_blank" rel="noopener noreferrer">https://link.springer.com/article/10.3758/s13414-012-0399-4</a>
-    </li>
-    <li>
-      Park, K. M., Cha, O., Kim, S., Im, H. Y., & Chong, S. C. (2007). The Influence of Depth Context on Blind Spot Filling-in. <i>Korean Journal of Cognitive Science, 18, 351–370</i>.
-    </li>
-    
-  </ul>
+{%- for pub in pubs -%}
+{%- unless pub.hide -%}
+{%- assign doi = pub.id | remove_first: "doi:" -%}
+{%- assign last_char = pub.title | slice: -1 -%}
+{%- comment %} normalise missing fields: nil and "" must both count as absent {% endcomment -%}
+{%- assign publisher = pub.publisher | default: "" -%}
+{%- assign volume = pub.volume | default: "" -%}
+{%- assign issue = pub.issue | default: "" -%}
+{%- assign pages = pub.pages | default: "" -%}
+  <li>
+    {{ pub.authors_apa }} ({{ pub.date | date: "%Y" }}). {{ pub.title }}{% unless last_char == "." or last_char == "?" or last_char == "!" %}.{% endunless %}
+    {%- if publisher != "" %}
+      <i>{{ publisher }}</i>
+      {%- if volume != "" %}, <i>{{ volume }}</i>{% if issue != "" %}({{ issue }}){% endif %}{% endif %}
+      {%- if pages != "" %}, {{ pages }}{% endif %}.
+    {%- endif %}
+    {% if pub.id contains "doi:" -%}
+      <a href="https://doi.org/{{ doi }}" target="_blank" rel="noopener noreferrer">https://doi.org/{{ doi }}</a>
+    {%- elsif pub.link -%}
+      <a href="{{ pub.link }}" target="_blank" rel="noopener noreferrer">{{ pub.link }}</a>
+    {%- endif %}
+  </li>
+{%- endunless -%}
+{%- endfor %}
+</ul>

--- a/_cite/util.py
+++ b/_cite/util.py
@@ -4,7 +4,9 @@ utility functions for cite process and plugins
 
 import subprocess
 import json
+import re
 import yaml
+from urllib.request import Request, urlopen
 from yaml.loader import SafeLoader
 from pathlib import Path
 from datetime import datetime
@@ -165,6 +167,93 @@ def save_data(path, data):
         raise Exception("Can't write to file")
 
 
+def strip_markup(text):
+    """
+    remove inline markup tags that some publishers embed in their metadata,
+    e.g. the "<scp>S</scp>ex-related" small-caps markup Wiley sends to Crossref.
+    Whitespace is collapsed too, since removing a tag can leave the line breaks
+    and indentation that surrounded it.
+    """
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", text)).strip()
+
+
+# lazily-loaded map of preferred author name forms, see _data/author-names.yaml
+_author_names = None
+
+
+def canonical_author(name):
+    """
+    look up the preferred display form of an author name, falling back to the
+    name as generated from publisher metadata
+    """
+    global _author_names
+    if _author_names is None:
+        try:
+            _author_names = load_data(Path("_data/author-names.yaml")) or {}
+        except Exception:
+            _author_names = {}
+    return _author_names.get(name, name)
+
+
+def author_initials(given):
+    """
+    convert a given name to APA-style initials, preserving hyphenation
+    ("Alexander J." -> "A. J.", "Hee-Yeon" -> "H.-Y.")
+    """
+    words = []
+    for word in given.split():
+        segments = [segment for segment in word.split("-") if segment]
+        words.append("-".join(segment[0].upper() + "." for segment in segments))
+    return " ".join(words)
+
+
+def format_authors(authors):
+    """
+    format a CSL author list APA-style,
+    e.g. "Song, M., Cook, A. J., & Im, H.-Y."
+    """
+    names = []
+    for author in authors:
+        given = strip_markup(get_safe(author, "given", "").strip())
+        family = strip_markup(get_safe(author, "family", "").strip())
+        if not (given or family):
+            continue
+        if given and family:
+            name = f"{family}, {author_initials(given)}"
+        else:
+            name = family or given
+        names.append(canonical_author(name))
+
+    if len(names) > 1:
+        return ", ".join(names[:-1]) + ", & " + names[-1]
+    return "".join(names)
+
+
+@log_cache
+@cache.memoize(name="crossref-print-year", expire=30 * (60 * 60 * 24))
+def crossref_print_year(_id):
+    """
+    look up the print (issue) year for a DOI from Crossref
+
+    Manubot reports the "issued" date, which for online-first papers is when
+    the paper first appeared online — often a year before the issue it gets
+    cited by. Reference lists use the issue year, so prefer that where Crossref
+    has one. Returns "" if unavailable, so callers fall back to the Manubot date.
+    """
+    if not _id.lower().startswith("doi:"):
+        return ""
+
+    try:
+        request = Request(
+            f"https://api.crossref.org/works/{_id[4:]}",
+            headers={"User-Agent": "imm-lab-website (https://www.imm-lab.ca)"},
+        )
+        message = json.loads(urlopen(request, timeout=30).read())["message"]
+        return str(message["published-print"]["date-parts"][0][0])
+    except Exception:
+        return ""
+
+
 @log_cache
 @cache.memoize(name="manubot", expire=90 * (60 * 60 * 24))
 def cite_with_manubot(_id):
@@ -193,7 +282,7 @@ def cite_with_manubot(_id):
     citation["id"] = _id
 
     # title
-    citation["title"] = get_safe(manubot, "title", "").strip()
+    citation["title"] = strip_markup(get_safe(manubot, "title", "").strip())
 
     # authors
     citation["authors"] = []
@@ -202,6 +291,14 @@ def cite_with_manubot(_id):
         family = get_safe(author, "family", "").strip()
         if given or family:
             citation["authors"].append(" ".join([given, family]))
+
+    # authors, formatted APA-style for reference lists
+    citation["authors_apa"] = format_authors(get_safe(manubot, "author", {}))
+
+    # volume, issue, and page or article number
+    citation["volume"] = str(get_safe(manubot, "volume", "")).strip()
+    citation["issue"] = str(get_safe(manubot, "issue", "")).strip()
+    citation["pages"] = str(get_safe(manubot, "page", "")).strip()
 
     # publisher
     container = get_safe(manubot, "container-title", "").strip()
@@ -226,6 +323,11 @@ def cite_with_manubot(_id):
     else:
         # if no year, consider date missing data
         citation["date"] = ""
+
+    # for online-first papers, cite the issue year rather than the online date
+    print_year = crossref_print_year(_id)
+    if print_year and not citation["date"].startswith(print_year):
+        citation["date"] = format_date(f"{print_year}-1-1")
 
     # link
     citation["link"] = get_safe(manubot, "URL", "").strip()

--- a/_data/author-names.yaml
+++ b/_data/author-names.yaml
@@ -1,0 +1,9 @@
+# Preferred display forms for author names.
+#
+# Publisher metadata is inconsistent about middle initials and hyphenation,
+# so the same person can be rendered several different ways across papers.
+# Keys are the form generated from publisher metadata; values are how the
+# name should appear in the publications list.
+
+"Im, H. Y.": "Im, H.-Y."
+"Giaschi, D.": "Giaschi, D. E."

--- a/_data/citations.yaml
+++ b/_data/citations.yaml
@@ -6,6 +6,10 @@
   - Alexander J. Cook
   - Hee Yeon Im
   - Deborah E. Giaschi
+  authors_apa: Cook, A. J., Im, H.-Y., & Giaschi, D. E.
+  volume: '173'
+  issue: ''
+  pages: '106165'
   publisher: Neuroscience &amp; Biobehavioral Reviews
   date: '2025-06-01'
   link: https://doi.org/g96x76
@@ -22,6 +26,11 @@
   - Reginald B. Adams
   - Jisoo Sun
   - Sang Chul Chong
+  authors_apa: Son, G., Im, H.-Y., Albohn, D. N., Kveraga, K., Adams, R. B., Sun,
+    J., & Chong, S. C.
+  volume: '13'
+  issue: '1'
+  pages: ''
   publisher: Scientific Reports
   date: '2023-11-07'
   link: https://doi.org/gs94m6
@@ -36,6 +45,10 @@
   - Young Jun Yoon
   - Sung Jun Joo
   - Sang Chul Chong
+  authors_apa: Cho, J., Im, H.-Y., Yoon, Y. J., Joo, S. J., & Chong, S. C.
+  volume: '13'
+  issue: '1'
+  pages: ''
   publisher: Scientific Reports
   date: '2023-08-31'
   link: https://doi.org/gs94m7
@@ -49,6 +62,10 @@
   - Hee Yeon Im
   - Joshua J. Liddy
   - Joo-Hyun Song
+  authors_apa: Im, H.-Y., Liddy, J. J., & Song, J.-H.
+  volume: '128'
+  issue: '3'
+  pages: 527-542
   publisher: Journal of Neurophysiology
   date: '2022-09-01'
   link: https://doi.org/gsc4tq
@@ -63,6 +80,10 @@
   - Cody A. Cushing
   - Noreen Ward
   - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Cushing, C. A., Ward, N., & Kveraga, K.
+  volume: '21'
+  issue: '4'
+  pages: 776-792
   publisher: Cognitive, Affective, &amp; Behavioral Neuroscience
   date: '2021-03-16'
   link: https://doi.org/gnjsp8
@@ -77,6 +98,10 @@
   - Hee Yeon Im
   - Noreen Ward
   - Reginald B. Adams
+  authors_apa: Kveraga, K., Im, H.-Y., Ward, N., & Adams, R. B.
+  volume: '20'
+  issue: '2'
+  pages: '9'
   publisher: Journal of Vision
   date: '2020-02-25'
   link: https://doi.org/gsc4tr
@@ -92,6 +117,10 @@
   - Reginald B Adams Jr
   - Noreen Ward
   - Kestutis Kveraga
+  authors_apa: Cushing, C. A., Im, H.-Y., Adams Jr, R. B., Ward, N., & Kveraga, K.
+  volume: '14'
+  issue: '2'
+  pages: 151-162
   publisher: Social Cognitive and Affective Neuroscience
   date: '2019-02-01'
   link: https://doi.org/ggbmwt
@@ -107,6 +136,11 @@
   - Hee Yeon Im
   - Daniel N. Albohn
   - Reginald B. Adams
+  authors_apa: Kveraga, K., De Vito, D., Cushing, C., Im, H.-Y., Albohn, D. N., &
+    Adams, R. B.
+  volume: '237'
+  issue: '4'
+  pages: 967-975
   publisher: Experimental Brain Research
   date: '2019-01-25'
   link: https://doi.org/gsc4ts
@@ -124,6 +158,11 @@
   - Noreen Ward
   - Daniel N. Albohn
   - Kestutis Kveraga
+  authors_apa: Adams, R. B., Im, H.-Y., Cushing, C., Boshyan, J., Ward, N., Albohn,
+    D. N., & Kveraga, K.
+  volume: ''
+  issue: ''
+  pages: 71-87
   publisher: Progress in Brain Research
   date: '2019-01-01'
   link: https://doi.org/ggsp8c
@@ -131,8 +170,8 @@
   plugin: orcid.py
   file: orcid.yaml
 - id: doi:10.1002/hbm.24035
-  title: "<scp>S</scp>\n                    ex\u2010related differences in behavioral\
-    \ and amygdalar responses to compound facial threat cues"
+  title: Sex-related differences in behavioral and amygdalar responses to compound
+    facial threat cues
   authors:
   - Hee Yeon Im
   - Reginald B. Adams
@@ -140,12 +179,17 @@
   - Jasmine Boshyan
   - Noreen Ward
   - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Adams, R. B., Cushing, C. A., Boshyan, J., Ward, N., & Kveraga,
+    K.
+  volume: '39'
+  issue: '7'
+  pages: 2725-2741
   publisher: Human Brain Mapping
   date: '2018-03-08'
   link: https://doi.org/gdv9gc
   orcid: 0000-0001-9379-1347
-  plugin: orcid.py
-  file: orcid.yaml
+  plugin: sources.py
+  file: sources.yaml
 - id: doi:10.1038/s41598-017-15495-2
   title: "Observer\u2019s anxiety facilitates magnocellular processing of clear facial\
     \ threat cues, but impairs parvocellular processing of ambiguous facial threat\
@@ -157,6 +201,11 @@
   - Noreen Ward
   - Cody A. Cushing
   - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Adams, R. B., Boshyan, J., Ward, N., Cushing, C. A., & Kveraga,
+    K.
+  volume: '7'
+  issue: '1'
+  pages: ''
   publisher: Scientific Reports
   date: '2017-11-09'
   link: https://doi.org/gck26w
@@ -173,6 +222,11 @@
   - Cody A. Cushing
   - Reginald B. Adams
   - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Albohn, D. N., Steiner, T. G., Cushing, C. A., Adams, R.
+    B., & Kveraga, K.
+  volume: '1'
+  issue: '11'
+  pages: 828-842
   publisher: Nature Human Behaviour
   date: '2017-10-09'
   link: https://doi.org/gnjsqc
@@ -189,12 +243,18 @@
   - Noreen Ward
   - Cody A. Cushing
   - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Adams, R. B., Boshyan, J., Ward, N., Cushing, C. A., & Kveraga,
+    K.
+  volume: ''
+  issue: ''
+  pages: ''
   publisher: openRxiv
   date: '2017-05-24'
   link: https://doi.org/gkvndj
   orcid: 0000-0001-9379-1347
-  plugin: orcid.py
-  file: orcid.yaml
+  plugin: sources.py
+  file: sources.yaml
+  hide: true
 - id: doi:10.1007/s40167-017-0058-7
   title: 'Correction to: Cross-cultural and hemispheric laterality effects on the
     ensemble coding of emotion in facial crowds'
@@ -206,12 +266,18 @@
   - Daniel N. Albohn
   - Reginald B. Adams
   - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
+    R. B., & Kveraga, K.
+  volume: '6'
+  issue: '1'
+  pages: 97-97
   publisher: Culture and Brain
-  date: '2017-12-22'
+  date: '2018-01-01'
   link: https://doi.org/gsc4tt
   orcid: 0000-0001-9379-1347
-  plugin: orcid.py
-  file: orcid.yaml
+  plugin: sources.py
+  file: sources.yaml
+  hide: true
 - id: doi:10.1101/141861
   title: Cross-cultural effects on ensemble coding of emotion in facial crowds
   authors:
@@ -222,12 +288,18 @@
   - Daniel N. Albohn
   - Reginald B. Adams
   - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
+    R. B., & Kveraga, K.
+  volume: ''
+  issue: ''
+  pages: ''
   publisher: openRxiv
   date: '2017-05-24'
   link: https://doi.org/gkxk5n
   orcid: 0000-0001-9379-1347
-  plugin: orcid.py
-  file: orcid.yaml
+  plugin: sources.py
+  file: sources.yaml
+  hide: true
 - id: doi:10.1016/j.visres.2015.08.013
   title: Grouping by proximity and the visual impression of approximate number in
     random dot arrays
@@ -235,6 +307,10 @@
   - Hee Yeon Im
   - Sheng-hua Zhong
   - Justin Halberda
+  authors_apa: Im, H.-Y., Zhong, S.-H., & Halberda, J.
+  volume: '126'
+  issue: ''
+  pages: 291-307
   publisher: Vision Research
   date: '2016-09-01'
   link: https://doi.org/f82pkn
@@ -247,6 +323,10 @@
   - Hee Yeon Im
   - "Patrick B\xE9dard"
   - Joo-Hyun Song
+  authors_apa: "Im, H.-Y., B\xE9dard, P., & Song, J.-H."
+  volume: '42'
+  issue: '9'
+  pages: 1269-1274
   publisher: 'Journal of Experimental Psychology: Human Perception and Performance'
   date: '2016-09-01'
   link: https://doi.org/f84n2c
@@ -259,6 +339,10 @@
   - Hee Yeon Im
   - "Patrick B\xE9dard"
   - Joo-Hyun Song
+  authors_apa: "Im, H.-Y., B\xE9dard, P., & Song, J.-H."
+  volume: '15'
+  issue: '8'
+  pages: '20'
   publisher: Journal of Vision
   date: '2015-06-26'
   link: https://doi.org/f7sbbf
@@ -274,8 +358,12 @@
   - Robert Eisinger
   - Ryan Ly
   - Justin Halberda
+  authors_apa: Odic, D., Im, H.-Y., Eisinger, R., Ly, R., & Halberda, J.
+  volume: '48'
+  issue: '2'
+  pages: 445-462
   publisher: Behavior Research Methods
-  date: '2015-05-19'
+  date: '2016-01-01'
   link: https://doi.org/f8vgnp
   orcid: 0000-0001-9379-1347
   plugin: orcid.py
@@ -285,6 +373,10 @@
   authors:
   - Hee Yeon Im
   - Sang Chul Chong
+  authors_apa: Im, H.-Y., & Chong, S. C.
+  volume: '43'
+  issue: '7'
+  pages: 663-676
   publisher: Perception
   date: '2014-01-01'
   link: https://doi.org/f6dsmh
@@ -297,8 +389,12 @@
   - Hee Yeon Im
   - Woon Ju Park
   - Sang Chul Chong
+  authors_apa: Im, H.-Y., Park, W. J., & Chong, S. C.
+  volume: '27'
+  issue: '1'
+  pages: 114-127
   publisher: Journal of Cognitive Psychology
-  date: '2014-12-08'
+  date: '2015-01-01'
   link: https://doi.org/gsc4tv
   orcid: 0000-0001-9379-1347
   plugin: orcid.py
@@ -309,8 +405,12 @@
   authors:
   - Hee Yeon Im
   - Justin Halberda
+  authors_apa: Im, H.-Y., & Halberda, J.
+  volume: '75'
+  issue: '2'
+  pages: 278-286
   publisher: Attention, Perception, &amp; Psychophysics
-  date: '2012-11-28'
+  date: '2013-01-01'
   link: https://doi.org/f4mqbv
   orcid: 0000-0001-9379-1347
   plugin: orcid.py
@@ -320,6 +420,10 @@
   authors:
   - H. Y. Im
   - S. C. Chong
+  authors_apa: Im, H.-Y., & Chong, S. C.
+  volume: '71'
+  issue: '2'
+  pages: 375-384
   publisher: Attention, Perception &amp; Psychophysics
   date: '2009-02-01'
   link: https://doi.org/fmn4kh
@@ -334,12 +438,16 @@
   - ' Sang Chul Chong'
   - ' Oakyoon Cha'
   - " \uC784\uD76C\uC5F0"
+  authors_apa: Park, K. M., Cha, O., Kim, S., Im, H.-Y., & Chong, S. C.
+  volume: '18'
+  issue: '4'
+  pages: 351-370
   publisher: Korean Journal of Cognitive Science
   date: '2007-12-01'
   link: https://doi.org/gsc4tw
   orcid: 0000-0001-9379-1347
-  plugin: orcid.py
-  file: orcid.yaml
+  plugin: sources.py
+  file: sources.yaml
 - id: doi:10.3758/s13414-020-02046-7
   title: An explicit investigation of the roles that feature distributions play in
     rapid visual categorization
@@ -347,8 +455,12 @@
   - Hee Yeon Im
   - Natalia A. Tiurina
   - Igor S. Utochkin
+  authors_apa: Im, H.-Y., Tiurina, N. A., & Utochkin, I. S.
+  volume: '83'
+  issue: '3'
+  pages: 1050-1069
   publisher: Attention, Perception, &amp; Psychophysics
-  date: '2020-05-14'
+  date: '2021-01-01'
   link: https://doi.org/gsc4tx
   orcid: 0000-0001-9379-1347
   plugin: orcid.py
@@ -363,12 +475,18 @@
   - Cody A. Cushing
   - Reginald B. Adams
   - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Albohn, D. N., Steiner, T. G., Cushing, C. A., Adams, R.
+    B., & Kveraga, K.
+  volume: ''
+  issue: ''
+  pages: ''
   publisher: openRxiv
   date: '2017-01-19'
   link: https://doi.org/gkws7j
   orcid: 0000-0001-9379-1347
-  plugin: orcid.py
-  file: orcid.yaml
+  plugin: sources.py
+  file: sources.yaml
+  hide: true
 - id: doi:10.1038/s41598-018-20509-8
   title: 'Neurodynamics and connectivity during facial fear perception: The role of
     threat exposure and signal congruity'
@@ -380,6 +498,11 @@
   - Daniel N. Albohn
   - Troy G. Steiner
   - Kestutis Kveraga
+  authors_apa: Cushing, C. A., Im, H.-Y., Adams, R. B., Ward, N., Albohn, D. N., Steiner,
+    T. G., & Kveraga, K.
+  volume: '8'
+  issue: '1'
+  pages: ''
   publisher: Scientific Reports
   date: '2018-02-09'
   link: https://doi.org/gc27t7
@@ -395,6 +518,10 @@
   - Advitya Hajela
   - Deborah Giaschi
   - Hee-Yeon Im
+  authors_apa: Song, M., Cook, A. J., Hajela, A., Giaschi, D. E., & Im, H.-Y.
+  volume: '339'
+  issue: ''
+  pages: '122145'
   publisher: NeuroImage
   date: '2026-10-01'
   link: https://doi.org/hcct5s
@@ -407,6 +534,10 @@
   - Alexander J. Cook
   - Deborah Giaschi
   - Hee Yeon Im
+  authors_apa: Cook, A. J., Giaschi, D. E., & Im, H.-Y.
+  volume: '35'
+  issue: '4'
+  pages: e70121
   publisher: Infant and Child Development
   date: '2026-07-01'
   link: https://doi.org/hcct5t
@@ -420,8 +551,33 @@
   - Cindy S. Ho
   - Hee Yeon Im
   - Deborah Eileen Giaschi
+  authors_apa: Asare, A. K., Ho, C. S., Im, H.-Y., & Giaschi, D. E.
+  volume: '240'
+  issue: ''
+  pages: '108745'
   publisher: Vision Research
   date: '2026-03-01'
   link: https://doi.org/hcct5v
+  plugin: sources.py
+  file: sources.yaml
+- id: doi:10.1007/s40167-017-0054-y
+  title: Cross-cultural and hemispheric laterality effects on the ensemble coding
+    of emotion in facial crowds
+  authors:
+  - Hee Yeon Im
+  - Sang Chul Chong
+  - Jisoo Sun
+  - Troy G. Steiner
+  - Daniel N. Albohn
+  - Reginald B. Adams
+  - Kestutis Kveraga
+  authors_apa: Im, H.-Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
+    R. B., & Kveraga, K.
+  volume: '5'
+  issue: '2'
+  pages: 125-152
+  publisher: Culture and Brain
+  date: '2017-10-01'
+  link: https://doi.org/hcct9n
   plugin: sources.py
   file: sources.yaml

--- a/_data/sources.yaml
+++ b/_data/sources.yaml
@@ -5,6 +5,38 @@
 
 - id: doi:10.1016/j.neuroimage.2026.122145
 
+# Crossref has no page or article number for this one, so supply it
 - id: doi:10.1002/icd.70121
+  pages: e70121
 
 - id: doi:10.1016/j.visres.2025.108745
+
+# ORCID lists only the correction notice for this paper, not the paper itself
+- id: doi:10.1007/s40167-017-0054-y
+
+# Crossref has this paper's authors as Hangul names in a different order to the
+# published article, and with no given/family split to build initials from
+- id: doi:10.19066/cogsci.2007.18.4.002
+  authors_apa: Park, K. M., Cha, O., Kim, S., Im, H.-Y., & Chong, S. C.
+
+# Wiley's Crossref record for this paper wraps the leading "S" in small-caps
+# markup, which leaves "S ex-related" once the tags are stripped. Override it.
+- id: doi:10.1002/hbm.24035
+  title: Sex-related differences in behavioral and amygdalar responses to compound facial threat cues
+
+# Entries below are pulled in automatically from ORCID but hidden from the
+# publications list: bioRxiv preprints of papers that later appeared in a
+# journal, and a publisher correction notice. Listing them alongside the
+# journal versions would duplicate the same work.
+
+- id: doi:10.1101/101527
+  hide: true
+
+- id: doi:10.1101/141838
+  hide: true
+
+- id: doi:10.1101/141861
+  hide: true
+
+- id: doi:10.1007/s40167-017-0058-7
+  hide: true

--- a/_plugins/misc.rb
+++ b/_plugins/misc.rb
@@ -42,7 +42,7 @@ module Jekyll
       weights = regex_scan(css, '--\S*:\s(\d{3});', false, true).sort.uniq
       url = "https://fonts.googleapis.com/css2?display=swap&"
       for name in names do
-        name.sub!" ", "+"
+        name.gsub!" ", "+"
         url += "&family=#{name}:ital,wght@"
         for ital in [0, 1] do
           for weight in weights do

--- a/_styles/-theme.scss
+++ b/_styles/-theme.scss
@@ -25,9 +25,9 @@
 
 :root {
   // font families
-  --title: "Barlow", sans-serif;
-  --heading: "Barlow", sans-serif;
-  --body: "Barlow", sans-serif;
+  --title: "Atkinson Hyperlegible Next", sans-serif;
+  --heading: "Atkinson Hyperlegible Next", sans-serif;
+  --body: "Atkinson Hyperlegible Next", sans-serif;
   --code: "Roboto Mono", monospace;
 
   // font sizes


### PR DESCRIPTION
## Publications page

The list was hand-written HTML and `_data/citations.yaml` fed nothing on the site. The page is now rendered from that data, keeping the existing plain hanging-indent look. **Adding a paper is now just a DOI in `_data/sources.yaml`.**

Making that work meant keeping metadata the pipeline was throwing away — `cite_with_manubot` kept "only needed info" and dropped volume, issue and pages, and flattened authors to `"Given Family"` strings with no way to build initials.

Content differences versus the old hand-written list:

- **Adds** Im & Chong (2009), *Computation of mean size is based on perceived size* — a real paper that was missing.
- **Corrects four years.** Manubot reports the online-first date, so PsiMLE showed 2015 (issue year 2016), *Ensemble statistics* 2014 (2015), *Effects of sampling* 2012 (2013), and *An explicit investigation* 2020 (2021). Crossref's print year is now preferred, matching how the papers are cited.
- **Hides** three bioRxiv preprints and a correction notice that duplicate journal versions.
- **Fixes** a Wiley metadata bug that rendered "S ex-related differences", and Hangul author names in the 2007 Korean Journal of Cognitive Science entry.
- Author names now render consistently via `_data/author-names.yaml` — "Giaschi, D. E." and "Im, H.-Y." throughout. Note the hyphenated initials, which is APA-correct for a hyphenated given name.

Also fixes the publications list forcing `color: #111`, which made it unreadable in dark mode.

## Font

Atkinson Hyperlegible Next site-wide. The original Atkinson Hyperlegible ships only weight 400 on Google Fonts, so the theme's 200/500/600 would have silently fallen back and flattened the heading hierarchy; the Next version covers all four.

## Verification

Built locally with Jekyll: 27 entries render, none malformed, and the generated Google Fonts URL returns 200 serving both families at all eight variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)