### PR TITLE
Use Inter as the site font; drop hyphen from Im initials

### DIFF
--- a/_data/author-names.yaml
+++ b/_data/author-names.yaml
@@ -4,6 +4,10 @@
 # so the same person can be rendered several different ways across papers.
 # Keys are the form generated from publisher metadata; values are how the
 # name should appear in the publications list.
+#
+# Note: citations are cached, so after editing this file locally delete
+# _cite/.cache before re-running _cite/cite.py. CI builds from a cold cache
+# and always picks changes up.
 
-"Im, H. Y.": "Im, H.-Y."
+"Im, H.-Y.": "Im, H. Y."
 "Giaschi, D.": "Giaschi, D. E."

--- a/_data/citations.yaml
+++ b/_data/citations.yaml
@@ -6,7 +6,7 @@
   - Alexander J. Cook
   - Hee Yeon Im
   - Deborah E. Giaschi
-  authors_apa: Cook, A. J., Im, H.-Y., & Giaschi, D. E.
+  authors_apa: Cook, A. J., Im, H. Y., & Giaschi, D. E.
   volume: '173'
   issue: ''
   pages: '106165'
@@ -26,7 +26,7 @@
   - Reginald B. Adams
   - Jisoo Sun
   - Sang Chul Chong
-  authors_apa: Son, G., Im, H.-Y., Albohn, D. N., Kveraga, K., Adams, R. B., Sun,
+  authors_apa: Son, G., Im, H. Y., Albohn, D. N., Kveraga, K., Adams, R. B., Sun,
     J., & Chong, S. C.
   volume: '13'
   issue: '1'
@@ -45,7 +45,7 @@
   - Young Jun Yoon
   - Sung Jun Joo
   - Sang Chul Chong
-  authors_apa: Cho, J., Im, H.-Y., Yoon, Y. J., Joo, S. J., & Chong, S. C.
+  authors_apa: Cho, J., Im, H. Y., Yoon, Y. J., Joo, S. J., & Chong, S. C.
   volume: '13'
   issue: '1'
   pages: ''
@@ -62,7 +62,7 @@
   - Hee Yeon Im
   - Joshua J. Liddy
   - Joo-Hyun Song
-  authors_apa: Im, H.-Y., Liddy, J. J., & Song, J.-H.
+  authors_apa: Im, H. Y., Liddy, J. J., & Song, J.-H.
   volume: '128'
   issue: '3'
   pages: 527-542
@@ -80,7 +80,7 @@
   - Cody A. Cushing
   - Noreen Ward
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Cushing, C. A., Ward, N., & Kveraga, K.
+  authors_apa: Im, H. Y., Cushing, C. A., Ward, N., & Kveraga, K.
   volume: '21'
   issue: '4'
   pages: 776-792
@@ -98,7 +98,7 @@
   - Hee Yeon Im
   - Noreen Ward
   - Reginald B. Adams
-  authors_apa: Kveraga, K., Im, H.-Y., Ward, N., & Adams, R. B.
+  authors_apa: Kveraga, K., Im, H. Y., Ward, N., & Adams, R. B.
   volume: '20'
   issue: '2'
   pages: '9'
@@ -117,7 +117,7 @@
   - Reginald B Adams Jr
   - Noreen Ward
   - Kestutis Kveraga
-  authors_apa: Cushing, C. A., Im, H.-Y., Adams Jr, R. B., Ward, N., & Kveraga, K.
+  authors_apa: Cushing, C. A., Im, H. Y., Adams Jr, R. B., Ward, N., & Kveraga, K.
   volume: '14'
   issue: '2'
   pages: 151-162
@@ -136,7 +136,7 @@
   - Hee Yeon Im
   - Daniel N. Albohn
   - Reginald B. Adams
-  authors_apa: Kveraga, K., De Vito, D., Cushing, C., Im, H.-Y., Albohn, D. N., &
+  authors_apa: Kveraga, K., De Vito, D., Cushing, C., Im, H. Y., Albohn, D. N., &
     Adams, R. B.
   volume: '237'
   issue: '4'
@@ -158,7 +158,7 @@
   - Noreen Ward
   - Daniel N. Albohn
   - Kestutis Kveraga
-  authors_apa: Adams, R. B., Im, H.-Y., Cushing, C., Boshyan, J., Ward, N., Albohn,
+  authors_apa: Adams, R. B., Im, H. Y., Cushing, C., Boshyan, J., Ward, N., Albohn,
     D. N., & Kveraga, K.
   volume: ''
   issue: ''
@@ -179,7 +179,7 @@
   - Jasmine Boshyan
   - Noreen Ward
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Adams, R. B., Cushing, C. A., Boshyan, J., Ward, N., & Kveraga,
+  authors_apa: Im, H. Y., Adams, R. B., Cushing, C. A., Boshyan, J., Ward, N., & Kveraga,
     K.
   volume: '39'
   issue: '7'
@@ -201,7 +201,7 @@
   - Noreen Ward
   - Cody A. Cushing
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Adams, R. B., Boshyan, J., Ward, N., Cushing, C. A., & Kveraga,
+  authors_apa: Im, H. Y., Adams, R. B., Boshyan, J., Ward, N., Cushing, C. A., & Kveraga,
     K.
   volume: '7'
   issue: '1'
@@ -222,7 +222,7 @@
   - Cody A. Cushing
   - Reginald B. Adams
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Albohn, D. N., Steiner, T. G., Cushing, C. A., Adams, R.
+  authors_apa: Im, H. Y., Albohn, D. N., Steiner, T. G., Cushing, C. A., Adams, R.
     B., & Kveraga, K.
   volume: '1'
   issue: '11'
@@ -243,7 +243,7 @@
   - Noreen Ward
   - Cody A. Cushing
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Adams, R. B., Boshyan, J., Ward, N., Cushing, C. A., & Kveraga,
+  authors_apa: Im, H. Y., Adams, R. B., Boshyan, J., Ward, N., Cushing, C. A., & Kveraga,
     K.
   volume: ''
   issue: ''
@@ -266,7 +266,7 @@
   - Daniel N. Albohn
   - Reginald B. Adams
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
+  authors_apa: Im, H. Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
     R. B., & Kveraga, K.
   volume: '6'
   issue: '1'
@@ -288,7 +288,7 @@
   - Daniel N. Albohn
   - Reginald B. Adams
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
+  authors_apa: Im, H. Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
     R. B., & Kveraga, K.
   volume: ''
   issue: ''
@@ -307,7 +307,7 @@
   - Hee Yeon Im
   - Sheng-hua Zhong
   - Justin Halberda
-  authors_apa: Im, H.-Y., Zhong, S.-H., & Halberda, J.
+  authors_apa: Im, H. Y., Zhong, S.-H., & Halberda, J.
   volume: '126'
   issue: ''
   pages: 291-307
@@ -323,7 +323,7 @@
   - Hee Yeon Im
   - "Patrick B\xE9dard"
   - Joo-Hyun Song
-  authors_apa: "Im, H.-Y., B\xE9dard, P., & Song, J.-H."
+  authors_apa: "Im, H. Y., B\xE9dard, P., & Song, J.-H."
   volume: '42'
   issue: '9'
   pages: 1269-1274
@@ -339,7 +339,7 @@
   - Hee Yeon Im
   - "Patrick B\xE9dard"
   - Joo-Hyun Song
-  authors_apa: "Im, H.-Y., B\xE9dard, P., & Song, J.-H."
+  authors_apa: "Im, H. Y., B\xE9dard, P., & Song, J.-H."
   volume: '15'
   issue: '8'
   pages: '20'
@@ -358,7 +358,7 @@
   - Robert Eisinger
   - Ryan Ly
   - Justin Halberda
-  authors_apa: Odic, D., Im, H.-Y., Eisinger, R., Ly, R., & Halberda, J.
+  authors_apa: Odic, D., Im, H. Y., Eisinger, R., Ly, R., & Halberda, J.
   volume: '48'
   issue: '2'
   pages: 445-462
@@ -373,7 +373,7 @@
   authors:
   - Hee Yeon Im
   - Sang Chul Chong
-  authors_apa: Im, H.-Y., & Chong, S. C.
+  authors_apa: Im, H. Y., & Chong, S. C.
   volume: '43'
   issue: '7'
   pages: 663-676
@@ -389,7 +389,7 @@
   - Hee Yeon Im
   - Woon Ju Park
   - Sang Chul Chong
-  authors_apa: Im, H.-Y., Park, W. J., & Chong, S. C.
+  authors_apa: Im, H. Y., Park, W. J., & Chong, S. C.
   volume: '27'
   issue: '1'
   pages: 114-127
@@ -405,7 +405,7 @@
   authors:
   - Hee Yeon Im
   - Justin Halberda
-  authors_apa: Im, H.-Y., & Halberda, J.
+  authors_apa: Im, H. Y., & Halberda, J.
   volume: '75'
   issue: '2'
   pages: 278-286
@@ -420,7 +420,7 @@
   authors:
   - H. Y. Im
   - S. C. Chong
-  authors_apa: Im, H.-Y., & Chong, S. C.
+  authors_apa: Im, H. Y., & Chong, S. C.
   volume: '71'
   issue: '2'
   pages: 375-384
@@ -438,7 +438,7 @@
   - ' Sang Chul Chong'
   - ' Oakyoon Cha'
   - " \uC784\uD76C\uC5F0"
-  authors_apa: Park, K. M., Cha, O., Kim, S., Im, H.-Y., & Chong, S. C.
+  authors_apa: Park, K. M., Cha, O., Kim, S., Im, H. Y., & Chong, S. C.
   volume: '18'
   issue: '4'
   pages: 351-370
@@ -455,7 +455,7 @@
   - Hee Yeon Im
   - Natalia A. Tiurina
   - Igor S. Utochkin
-  authors_apa: Im, H.-Y., Tiurina, N. A., & Utochkin, I. S.
+  authors_apa: Im, H. Y., Tiurina, N. A., & Utochkin, I. S.
   volume: '83'
   issue: '3'
   pages: 1050-1069
@@ -475,7 +475,7 @@
   - Cody A. Cushing
   - Reginald B. Adams
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Albohn, D. N., Steiner, T. G., Cushing, C. A., Adams, R.
+  authors_apa: Im, H. Y., Albohn, D. N., Steiner, T. G., Cushing, C. A., Adams, R.
     B., & Kveraga, K.
   volume: ''
   issue: ''
@@ -498,7 +498,7 @@
   - Daniel N. Albohn
   - Troy G. Steiner
   - Kestutis Kveraga
-  authors_apa: Cushing, C. A., Im, H.-Y., Adams, R. B., Ward, N., Albohn, D. N., Steiner,
+  authors_apa: Cushing, C. A., Im, H. Y., Adams, R. B., Ward, N., Albohn, D. N., Steiner,
     T. G., & Kveraga, K.
   volume: '8'
   issue: '1'
@@ -518,7 +518,7 @@
   - Advitya Hajela
   - Deborah Giaschi
   - Hee-Yeon Im
-  authors_apa: Song, M., Cook, A. J., Hajela, A., Giaschi, D. E., & Im, H.-Y.
+  authors_apa: Song, M., Cook, A. J., Hajela, A., Giaschi, D. E., & Im, H. Y.
   volume: '339'
   issue: ''
   pages: '122145'
@@ -534,7 +534,7 @@
   - Alexander J. Cook
   - Deborah Giaschi
   - Hee Yeon Im
-  authors_apa: Cook, A. J., Giaschi, D. E., & Im, H.-Y.
+  authors_apa: Cook, A. J., Giaschi, D. E., & Im, H. Y.
   volume: '35'
   issue: '4'
   pages: e70121
@@ -551,7 +551,7 @@
   - Cindy S. Ho
   - Hee Yeon Im
   - Deborah Eileen Giaschi
-  authors_apa: Asare, A. K., Ho, C. S., Im, H.-Y., & Giaschi, D. E.
+  authors_apa: Asare, A. K., Ho, C. S., Im, H. Y., & Giaschi, D. E.
   volume: '240'
   issue: ''
   pages: '108745'
@@ -571,7 +571,7 @@
   - Daniel N. Albohn
   - Reginald B. Adams
   - Kestutis Kveraga
-  authors_apa: Im, H.-Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
+  authors_apa: Im, H. Y., Chong, S. C., Sun, J., Steiner, T. G., Albohn, D. N., Adams,
     R. B., & Kveraga, K.
   volume: '5'
   issue: '2'

--- a/_data/sources.yaml
+++ b/_data/sources.yaml
@@ -17,7 +17,7 @@
 # Crossref has this paper's authors as Hangul names in a different order to the
 # published article, and with no given/family split to build initials from
 - id: doi:10.19066/cogsci.2007.18.4.002
-  authors_apa: Park, K. M., Cha, O., Kim, S., Im, H.-Y., & Chong, S. C.
+  authors_apa: Park, K. M., Cha, O., Kim, S., Im, H. Y., & Chong, S. C.
 
 # Wiley's Crossref record for this paper wraps the leading "S" in small-caps
 # markup, which leaves "S ex-related" once the tags are stripped. Override it.

--- a/_styles/-theme.scss
+++ b/_styles/-theme.scss
@@ -25,9 +25,9 @@
 
 :root {
   // font families
-  --title: "Atkinson Hyperlegible Next", sans-serif;
-  --heading: "Atkinson Hyperlegible Next", sans-serif;
-  --body: "Atkinson Hyperlegible Next", sans-serif;
+  --title: "Inter", sans-serif;
+  --heading: "Inter", sans-serif;
+  --body: "Inter", sans-serif;
   --code: "Roboto Mono", monospace;
 
   // font sizes


### PR DESCRIPTION
Switches the site font from Atkinson Hyperlegible Next to **Inter**. Inter serves all four theme weights (200/400/500/600) in both roman and italic, so the heading hierarchy is preserved.

Also changes the author name map so Hee-Yeon Im's initials render as **"Im, H. Y."** rather than the hyphenated "Im, H.-Y.", including the hardcoded override on the 2007 Korean Journal of Cognitive Science entry.

Verified locally: 27 entries render, none malformed, all 27 author credits read "Im, H. Y.", and the generated Google Fonts URL requests Inter at all eight variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)